### PR TITLE
fix a type

### DIFF
--- a/veneer/general.py
+++ b/veneer/general.py
@@ -422,7 +422,7 @@ class Veneer(object):
         '''
         assert self.live_source
         resp = requests.delete(self.url('/runs/%s' % str(run)))
-        reps.raise_for_status()
+        resp.raise_for_status()
         code = resp.status_code
         content = resp.text
         return code


### PR DESCRIPTION
fix a type that throws the following error

```
  File "veneer\general.py", line 436, in drop_all_runs
  File "veneer\general.py", line 425, in drop_run
NameError: name 'reps' is not defined. Did you mean: 'repr'?
```